### PR TITLE
Check a pipeline result has targets before using it.

### DIFF
--- a/src/main/java/frc/robot/util/Vision/Vision.java
+++ b/src/main/java/frc/robot/util/Vision/Vision.java
@@ -600,9 +600,12 @@ public class Vision {
       // The latest camera results
       for(PhotonPipelineResult result : inputs.results){
         // TODO: This could be improved by averaging all targets instead of only using 1
+
+        // Continue if the target doesn't exist or it should be ignored
+        if (!result.hasTargets()) continue;
         // Gets the best target to use for the calculations
         PhotonTrackedTarget target = result.getBestTarget();
-        // Continue if the target doesn't exist or it should be ignored
+        // I don't know why this would happen, but keep it in just in case
         if(target==null){
           continue;
         }


### PR DESCRIPTION
The null check works fine, but produces warnings.

It builds, and shouldn't change anything.

Should stop this warning from occurring again.

![error](https://github.com/user-attachments/assets/9a3d9fb1-3542-4ec2-9749-a97dcce1a5d1)
