### PR TITLE
Working simulation

### DIFF
--- a/src/main/java/frc/robot/RobotId.java
+++ b/src/main/java/frc/robot/RobotId.java
@@ -1,7 +1,5 @@
 package frc.robot;
 
-import frc.robot.constants.Constants;
-
 import edu.wpi.first.wpilibj.Preferences;
 
 /**
@@ -74,7 +72,7 @@ public enum RobotId {
         }
 
         if (robotId == RobotId.Default) {
-            if (Constants.CURRENT_MODE == Constants.Mode.SIM) {
+            if (Robot.isSimulation()) {
                 robotId = RobotId.SwerveCompetition; // Default to competition robot for simulation
             } else {
                 throw new RuntimeException("RobotId is set to Default (or was unset)! Please set it to something.");

--- a/src/main/java/frc/robot/RobotId.java
+++ b/src/main/java/frc/robot/RobotId.java
@@ -1,5 +1,7 @@
 package frc.robot;
 
+import frc.robot.constants.Constants;
+
 import edu.wpi.first.wpilibj.Preferences;
 
 /**
@@ -71,9 +73,13 @@ public enum RobotId {
             }
         }
 
-		if (robotId == RobotId.Default) {
-			throw new RuntimeException("RobotId is set to Default (or was unset)! Please set it to something.");
-		}
+        if (robotId == RobotId.Default) {
+            if (Constants.CURRENT_MODE == Constants.Mode.SIM) {
+                robotId = RobotId.SwerveCompetition; // Default to competition robot for simulation
+            } else {
+                throw new RuntimeException("RobotId is set to Default (or was unset)! Please set it to something.");
+            }
+        }
 
         // return the robot identity
         return robotId;


### PR DESCRIPTION
Set the default RobotId to SwerveCompetition when running in simulation. Small fix that allows the simulation to deploy properly.