### PR TITLE
Change constant

### DIFF
--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -14,7 +14,6 @@ public class Constants {
 
     // CAN bus names
     public static final CANBus CANIVORE_CAN = new CANBus("CANivore");
-    public static final CANBus SUBSYSTEM_CANIVORE_CAN = CANIVORE_CAN;
     public static final CANBus CANIVORE_SUB = new CANBus("CANivoreSub");
     public static final CANBus RIO_CAN = new CANBus("rio");
 

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -14,6 +14,7 @@ public class Constants {
 
     // CAN bus names
     public static final CANBus CANIVORE_CAN = new CANBus("CANivore");
+    public static final CANBus SUBSYSTEM_CANIVORE_CAN = CANIVORE_CAN;
     public static final CANBus CANIVORE_SUB = new CANBus("CANivoreSub");
     public static final CANBus RIO_CAN = new CANBus("rio");
 

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -19,7 +19,7 @@ import frc.robot.constants.Constants;
 import frc.robot.constants.IdConstants;
 
 public class Hood extends SubsystemBase implements HoodIO{
-    private TalonFX motor = new TalonFX(IdConstants.HOOD_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
+    private TalonFX motor = new TalonFX(IdConstants.HOOD_ID, Constants.CANIVORE_SUB);
 
 	private final LinearFilter setpointFilter = LinearFilter.singlePoleIIR(0.02, 0.02);
 

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -19,8 +19,8 @@ import frc.robot.constants.IdConstants;
 
 public class Shooter extends SubsystemBase implements ShooterIO {
     
-    private TalonFX shooterMotorLeft = new TalonFX(IdConstants.SHOOTER_LEFT_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
-    private TalonFX shooterMotorRight = new TalonFX(IdConstants.SHOOTER_RIGHT_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
+    private TalonFX shooterMotorLeft = new TalonFX(IdConstants.SHOOTER_LEFT_ID, Constants.CANIVORE_SUB);
+    private TalonFX shooterMotorRight = new TalonFX(IdConstants.SHOOTER_RIGHT_ID, Constants.CANIVORE_SUB);
 
     // Goal Velocity / Double theCircumfrence
     private double shooterTargetSpeed = 0;

--- a/src/main/java/frc/robot/subsystems/turret/Turret.java
+++ b/src/main/java/frc/robot/subsystems/turret/Turret.java
@@ -32,9 +32,9 @@ public class Turret extends SubsystemBase implements TurretIO{
 
 	/* ---------------- Hardware ---------------- */
 
-	private final TalonFX motor = new TalonFX(IdConstants.TURRET_MOTOR_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
-	private final CANcoder encoderLeft = new CANcoder(IdConstants.TURRET_ENCODER_LEFT_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
-    private final CANcoder encoderRight = new CANcoder(IdConstants.TURRET_ENCODER_RIGHT_ID, Constants.SUBSYSTEM_CANIVORE_CAN);
+	private final TalonFX motor = new TalonFX(IdConstants.TURRET_MOTOR_ID, Constants.CANIVORE_SUB);
+	private final CANcoder encoderLeft = new CANcoder(IdConstants.TURRET_ENCODER_LEFT_ID, Constants.CANIVORE_SUB);
+    private final CANcoder encoderRight = new CANcoder(IdConstants.TURRET_ENCODER_RIGHT_ID, Constants.CANIVORE_SUB);
 
 	private TalonFXSimState simState;
 	private SingleJointedArmSim turretSim;


### PR DESCRIPTION
## Overview
This PR fixes a build error by switching the shooter, hood, and turret subsystems to use the existing CANIVORE_SUB constant instead of the SUBSYSTEM_CANIVORE_CAN constant that doesn’t exist.

## Tests Ran
Code builds.