### PR TITLE
better stuff

### DIFF
--- a/src/main/java/frc/robot/subsystems/spindexer/Spindexer.java
+++ b/src/main/java/frc/robot/subsystems/spindexer/Spindexer.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.spindexer;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
-import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
 

--- a/src/main/java/frc/robot/subsystems/spindexer/Spindexer.java
+++ b/src/main/java/frc/robot/subsystems/spindexer/Spindexer.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.spindexer;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.controls.DutyCycleOut;
+import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
 
 import org.littletonrobotics.junction.Logger;
@@ -66,18 +67,18 @@ public class Spindexer extends SubsystemBase implements SpindexerIO {
         }
 
         if (state == SpindexerState.MAX) {
-            motor.setControl(new DutyCycleOut(SpindexerConstants.spindexerMaxPower).withEnableFOC(true));
+            motor.setControl(new VoltageOut(12 * SpindexerConstants.spindexerMaxPower).withEnableFOC(true));
             reversing = false;
         } else if (state == SpindexerState.REVERSE) {
-            motor.setControl(new DutyCycleOut(SpindexerConstants.spindexerReversePower).withEnableFOC(true));
+            motor.setControl(new VoltageOut(12 * SpindexerConstants.spindexerReversePower).withEnableFOC(true));
             reversing = true;
         } else if (state == SpindexerState.STOPPED) {
-            motor.setControl(new DutyCycleOut(0.0).withEnableFOC(true));
+            motor.setControl(new VoltageOut(12 * 0.0).withEnableFOC(true));
             reversing = false;
         } else if (state == SpindexerState.RESET && resetPos != null) {
-            motor.setControl(new DutyCycleOut(resetPID.calculate((motor.getPosition().getValueAsDouble() / gearRatio) % 1.0, resetPos)).withEnableFOC(true));
+            motor.setControl(new VoltageOut(12 * resetPID.calculate((motor.getPosition().getValueAsDouble() / gearRatio) % 1.0, resetPos)).withEnableFOC(true));
         } else {
-            motor.setControl(new DutyCycleOut(power).withEnableFOC(true));
+            motor.setControl(new VoltageOut(12 * power).withEnableFOC(true));
             reversing = false;
         }
 


### PR DESCRIPTION
changes dutycycleout to voltageout, because duty cycle multiplies by battery voltage, making it so that our spindexer is weaker when we are doing other stuff. All you have to do is multipy whaterver is in VoltageOut by 12 and its basically the same, but better
